### PR TITLE
Allow hook to not provide a default. 

### DIFF
--- a/src/Hook.php
+++ b/src/Hook.php
@@ -185,7 +185,8 @@ class Hook
     {
         // Create void callback object if none set.
         if (!$callback) {
-            $callback = function() {};
+            $callback = function () {
+            };
         }
 
         return new Callback($callback, $params);

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -181,8 +181,13 @@ class Hook
      *
      * @return \CoInvestor\LaraHook\Callback
      */
-    protected function createCallbackObject(callable $callback, array $params): Callback
+    protected function createCallbackObject(callable $callback = null, array $params = []): Callback
     {
+        // Create void callback object if none set.
+        if (!$callback) {
+            $callback = function() {};
+        }
+
         return new Callback($callback, $params);
     }
 

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -259,7 +259,7 @@ class Hook
     private function detectCallerInformation(): array
     {
         // Use backtrace to determine where the current listener is defined.
-        $trace = debug_backtrace(null, 5);
+        $trace = debug_backtrace(0, 5);
         // 0 is this method, and 1 is this libraries hook.
         $depth = 2;
 

--- a/tests/HookTest.php
+++ b/tests/HookTest.php
@@ -37,6 +37,34 @@ class HookTests extends TestCase
     }
 
     /**
+     * Ensure hook can be registered with no default value.
+     * 
+     * @group noVal
+     * @return void
+     */
+    public function testGetNoDefaultValue()
+    {
+        $result = Hook::get(
+            "test_name",
+            ['arg1', 'arg2']
+        );
+
+        $this->assertEquals(null, $result);
+        $this->assertFalse(Hook::hasListeners('test_name'));
+
+        Hook::listen("test_name", function ($callback, $output, $arg1, $arg2) {
+            return "hooked" . $arg1 . $arg2 . $callback->call();
+        }, 1);
+
+        $result = Hook::get(
+            "test_name",
+            ['a', 'b']
+        );
+
+        $this->assertEquals('hookedab', $result);
+    }
+
+    /**
      * Confirm listener runs when hook is called
      * @return void
      */

--- a/tests/HookTest.php
+++ b/tests/HookTest.php
@@ -38,7 +38,7 @@ class HookTests extends TestCase
 
     /**
      * Ensure hook can be registered with no default value.
-     * 
+     *
      * @group noVal
      * @return void
      */


### PR DESCRIPTION
Fix bug where no providing a callback method (or setting it to null) would cause errors.
No default value or callback is a valid usecase for some hooks so we should ensure this works as expected. Doubly so given null is an accepted value for the `Hook::get` method.
