### PR TITLE
Fix bug with multiple hooks in a blade template

### DIFF
--- a/src/HookServiceProvider.php
+++ b/src/HookServiceProvider.php
@@ -36,15 +36,12 @@ class HookServiceProvider extends ServiceProvider
             // $parameters[1] => bool => is this wrapper component?
             if (!isset($parameters[1])) {
                 return '<?php
-
-                use CoInvestor\LaraHook\Facades\Hook;
-
                 $__definedVars = (get_defined_vars()["__data"]);
                 if (empty($__definedVars))
                 {
                     $__definedVars = [];
                 }
-                $output = Hook::get(
+                $output = \CoInvestor\LaraHook\Facades\Hook::get(
                     "template.' . $name . '",
                     ["data"=>$__definedVars],
                     function($data) { return null; }
@@ -62,8 +59,6 @@ class HookServiceProvider extends ServiceProvider
 
         Blade::directive('endhook', function ($parameter) {
             return '<?php
-                use CoInvestor\LaraHook\Facades\Hook;
-
                 $__definedVars = (get_defined_vars()["__data"]);
                 if (empty($__definedVars))
                 {
@@ -71,7 +66,7 @@ class HookServiceProvider extends ServiceProvider
                 }
                 $__hook_content = ob_get_clean();
 
-                $output = Hook::get(
+                $output = \CoInvestor\LaraHook\Facades\Hook::get(
                     "template.$__hook_name",
                     ["data"=>$__definedVars],
                     function($data) use ($__hook_content) { return $__hook_content; },

--- a/tests/HookBladeTest.php
+++ b/tests/HookBladeTest.php
@@ -58,6 +58,21 @@ class HookBladeTest extends TestCase
         $view->assertSee('<p>Hi Battlemaster Sally</p>', false);
     }
 
+    public function testMultipleBladeHook()
+    {
+        Hook::listen('template.test', function ($callback, $output, $variables) {
+            return $this->blade('{{ $name }}', $variables);
+        });
+
+        Hook::listen('template.thing', function ($callback, $output, $variables) {
+            return $this->blade('science', $variables);
+        });
+
+
+        $view = $this->blade('<p>Hi @hook(\'test\') I like @hook(\'thing\')</p>', ['name' => 'Sally']);
+        $view->assertSee('<p>Hi Sally I like science</p>', false);
+    }
+
     public function testWrappedBladeHookManipulateInner()
     {
         $view = $this->blade('@hook(\'test\', true)This is some text.@endhook');


### PR DESCRIPTION
Previously the blade template was making use of a `use` statement to import the hook facade - this meant when multiple hooks were set within the blade template, the use statement would get generated in to the result multiple times causing ` Cannot use CoInvestor\LaraHook\Facades\Hook as Hook because the name is already in use in ...` errors.

This has been resolved by swapping over to using the fully qualified facade name instead.
A test has been added to ensure this functions as expected.

Thanks to https://github.com/CoInvestor/larahook/issues/6 for reporting this bug.