### PR TITLE
Add `clearListeners` and `reset` methods

### DIFF
--- a/src/Hook.php
+++ b/src/Hook.php
@@ -99,12 +99,49 @@ class Hook
         ksort($this->watch[$hook]);
     }
 
+    /**
+     * Remove all listeners on a particular hook
+     *
+     * @param  string $hook [description]
+     * @return bool       [description]
+     */
     public function removeListeners(string $hook): bool
     {
         $this->watch[$hook] = [];
         return true;
     }
 
+    /**
+     * Clear all existing listeners
+     * @return bool [description]
+     */
+    public function clearListeners(): bool
+    {
+        $this->watch = [];
+        return true;
+    }
+
+    /**
+     * Reset all hooks. Returns to default state with any hooks, mocks or stops removed.
+     *
+     * @return  bool
+     */
+    public function reset(): bool
+    {
+        $this->clearListeners();
+        $this->stop = [];
+        $this->mock = [];
+        $this->testing = true;
+        return true;
+    }
+
+    /**
+     * Remove specific listener
+     *
+     * @param  string   $hook     [description]
+     * @param  callable $function [description]
+     * @return [type]             [description]
+     */
     public function removeListener(string $hook, callable $function): bool
     {
         foreach ($this->watch[$hook] as $priority => $hooks) {

--- a/tests/HookTest.php
+++ b/tests/HookTest.php
@@ -400,4 +400,80 @@ class HookTests extends TestCase
             return 'default';
         }));
     }
+
+    /**
+     * Remove clear listeners
+     *
+     * @return void
+     */
+    public function testClearListeners()
+    {
+        $method = function ($callback, $output) {
+            return $output . "AAA";
+        };
+
+        Hook::listen("test", $method);
+        Hook::listen("test", function ($callback, $output) {
+            return $output . "BBB";
+        });
+
+        $this->assertEquals('AAABBB', Hook::get("test", [], function () {
+            return 'default';
+        }));
+
+        $this->assertTrue(Hook::clearListeners());
+
+        $this->assertEquals('default', Hook::get("test", [], function () {
+            return 'default';
+        }));
+    }
+
+    /**
+     * Remove clear listeners
+     *
+     * @return void
+     */
+    public function testReset()
+    {
+        $method = function ($callback, $output) {
+            return $output . "AAA";
+        };
+
+        // Listeners
+        Hook::listen("test", $method);
+        Hook::listen("test", function ($callback, $output) {
+            return $output . "BBB";
+        });
+
+        $this->assertEquals('AAABBB', Hook::get("test", [], function () {
+            return 'default';
+        }));
+
+        // Mock
+        Hook::mock('test_name', 'mockvalue');
+        $result = Hook::get(
+            "test_name",
+            [],
+            function () {
+                return "default";
+            }
+        );
+        $this->assertEquals($result, 'mockvalue');
+
+        // And clear
+        $this->assertTrue(Hook::reset());
+
+        $this->assertEquals('default', Hook::get("test", [], function () {
+            return 'default';
+        }));
+
+        $result = Hook::get(
+            "test_name",
+            [],
+            function () {
+                return "default";
+            }
+        );
+        $this->assertEquals($result, 'default');
+    }
 }


### PR DESCRIPTION
When testing functionality there are cases when we want only a small subset of hooks to be in effect. This PR adds the ability to clear all active via `clearListeners`, so only the desired ones are setup. 

I have additionally added the ability to do a full `reset` of the library, which in addition to clearing listeners, will also reset any stops or mocks that have been configured.

Tests have been added for the new methods.